### PR TITLE
feat: add Mento Token tests

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -26,6 +26,7 @@ const config: HardhatUserConfig = {
       },
       chainId: getNetworkConfig().chainId,
       hardfork: 'berlin',
+      gasPrice: 0,
     },
   },
 };

--- a/test/MentoToken.test.ts
+++ b/test/MentoToken.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import hre, { ethers } from 'hardhat';
 import * as mento from '@mento-protocol/mento-sdk';
+import * as helpers from '@nomicfoundation/hardhat-toolbox/network-helpers';
 
 import { MentoToken, MentoToken__factory } from '@mento-protocol/mento-core-ts';
 
@@ -10,9 +11,14 @@ describe('Mento Token', function () {
   let governanceAddresses: mento.ContractAddresses;
   let mentoToken: MentoToken;
 
+  beforeEach(async function () {
+    // reset the fork state between tests to not pollute the state
+    // @ts-expect-error - forking doesn't exist in hre for some reason
+    await helpers.reset(hre.network.config.forking.url);
+  });
+
   before(async function () {
     const chainId = hre.network.config.chainId;
-
     if (!chainId) {
       throw new Error('Chain ID not found');
     }
@@ -33,10 +39,80 @@ describe('Mento Token', function () {
     console.log('========================\r\n');
   });
 
-  it('Should have supply gte initial supply', async function () {
+  it('should have supply gte initial supply', async function () {
     const totalSupply = await mentoToken.totalSupply();
     const initialTokenSupply = parseEther('350000000');
 
     expect(totalSupply).greaterThanOrEqual(initialTokenSupply);
+  });
+
+  it('should revert when mint is called by an address != Emission', async function () {
+    const [addr] = await ethers.getSigners();
+    await expect(
+      mentoToken.connect(addr!).mint(addr!.address, parseEther('1')),
+    ).to.be.revertedWith('MentoToken: only emission contract');
+  });
+
+  it('should successfully mint when called by the Emission contract', async function () {
+    const emissionSigner = await ethers.getImpersonatedSigner(
+      governanceAddresses.Emission,
+    );
+    const [receiver] = await ethers.getSigners();
+    const supplyBefore = await mentoToken.totalSupply();
+    const amount = parseEther('100');
+
+    expect(await mentoToken.balanceOf(receiver!.address)).to.equal(0);
+
+    await mentoToken.connect(emissionSigner!).mint(receiver!.address, amount);
+    expect(await mentoToken.totalSupply()).to.equal(supplyBefore + amount);
+    expect(await mentoToken.balanceOf(receiver!.address)).to.equal(amount);
+  });
+
+  it('should allow for tokens to be transferred', async function () {
+    const emissionSigner = await ethers.getImpersonatedSigner(
+      governanceAddresses.Emission,
+    );
+    const [bob, alice] = await ethers.getSigners();
+    const supplyBefore = await mentoToken.totalSupply();
+    const amountToMint = parseEther('1337');
+
+    expect(await mentoToken.balanceOf(bob!.address)).to.equal(0);
+    expect(await mentoToken.balanceOf(alice!.address)).to.equal(0);
+
+    await mentoToken.connect(emissionSigner!).mint(bob!.address, amountToMint);
+
+    const amountToTransfer = parseEther('123');
+    await mentoToken.connect(bob!).transfer(alice!.address, amountToTransfer);
+    expect(await mentoToken.balanceOf(bob!.address)).to.equal(
+      amountToMint - amountToTransfer,
+    );
+    expect(await mentoToken.balanceOf(alice!.address)).to.equal(
+      amountToTransfer,
+    );
+    expect(await mentoToken.totalSupply()).to.equal(
+      supplyBefore + amountToMint,
+    );
+  });
+
+  it('should allow for tokens to be burned', async function () {
+    const emissionSigner = await ethers.getImpersonatedSigner(
+      governanceAddresses.Emission,
+    );
+    const [bob] = await ethers.getSigners();
+    const supplyBefore = await mentoToken.totalSupply();
+    const amountToMint = parseEther('1337');
+
+    expect(await mentoToken.balanceOf(bob!.address)).to.equal(0);
+
+    await mentoToken.connect(emissionSigner!).mint(bob!.address, amountToMint);
+
+    const amountToBurn = parseEther('456');
+    await mentoToken.connect(bob!).burn(amountToBurn);
+    expect(await mentoToken.balanceOf(bob!.address)).to.equal(
+      amountToMint - amountToBurn,
+    );
+    expect(await mentoToken.totalSupply()).to.equal(
+      supplyBefore + amountToMint - amountToBurn,
+    );
   });
 });


### PR DESCRIPTION
### Description

This adds a few basic tests on MentoToken.sol according to the [governance test plan](https://www.notion.so/mentolabs/Governance-Test-Plan-4c38412bebe74095b025b26d2dc34ac0#13d5a1c3e97a48108e19d2a6444ddc4f):

```
❯ pnpm test:alfajores


> governance-tests@1.0.0 test:alfajores /Users/xyznelson/mento/governance-tests
> NETWORK=alfajores pnpm exec hardhat test



  Mento Token

========================
Running Mento Token tests on network with chain id: 44787
========================

    ✔ should have supply gte initial supply (403ms)
    ✔ should revert when mint is called by an address != Emission (334ms)
    ✔ should successfully mint when called by the Emission contract (795ms)
    ✔ should allow for tokens to be transferred (866ms)
    ✔ should allow for tokens to be burned (784ms)


  5 passing (11s)
```

### Other changes

- Set `gasPrice` under the hardhat config to `0` as otherwise all accounts used for sending txs need to be funded: `InvalidInputError: sender doesn't have enough funds to send tx. The max upfront cost is: 240000000000000000 and the sender's account only has: 0`

### Related issues

- Fixes https://github.com/mento-protocol/governance-tests/issues/4
